### PR TITLE
Add jquery.min.js to catch ready event in custom javascript

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/LabelMaker/print_labels.tt
+++ b/Koha/Plugin/Com/ByWaterSolutions/LabelMaker/print_labels.tt
@@ -9,6 +9,7 @@
         <style>
             [% labels_printer_profile.content %]
         </style>
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
     </head>
 
     <body>


### PR DESCRIPTION
Hello! My name is Pablo A. Jones from Trelew Chubut Argentina, I would like to add jquery.min.js to be able to execute javascript code when the page is loaded (document.ready event). The code that is executed allows to separate for example: "324.282 / G 146" in "324.282 <br> G 146"
![etiquetas](https://user-images.githubusercontent.com/34864272/69438657-2ccf7a80-0d24-11ea-98c1-d26a5459a221.png).
Regards!
